### PR TITLE
Use upsert statement when inserting to postgres state store

### DIFF
--- a/resources/durablestore_postgres.sql
+++ b/resources/durablestore_postgres.sql
@@ -32,4 +32,5 @@ CREATE TABLE IF NOT EXISTS states_store
     shard_number    BIGINT                NOT NULL,
 
     PRIMARY KEY (persistence_id, version_number)
+    CONSTRAINT unique_persistence_id UNIQUE (persistence_id)
 );

--- a/resources/durablestore_postgres.sql
+++ b/resources/durablestore_postgres.sql
@@ -32,5 +32,6 @@ CREATE TABLE IF NOT EXISTS states_store
     shard_number    BIGINT                NOT NULL,
 
     PRIMARY KEY (persistence_id, version_number)
-    CONSTRAINT unique_persistence_id UNIQUE (persistence_id)
+   CREATE INDEX IF NOT EXISTS idx_states_store_persistence_id ON events_store(persistence_id);
+   CREATE INDEX IF NOT EXISTS idx_states_store_version_number ON events_store(version_number);
 );


### PR DESCRIPTION
# Summary

> [!WARNING]  
> I'm not 100% sure if this implementation is accurate and produce the same result as previous one

When I was trying the Postgres state store, my test application was stuck after creating less than 10 actors. After figuring out the bottleneck, it seems like the DELETE statement is causing the PostgreSQL to be slow.

My initial thought is, DELETE statement is there to ensure that there's only 1 row for each actor exists in the database. Please correct me if I'm wrong.

I swapped the `DELETE` SQL statement to use `INSERT .... ON CONFLICT` SQL. Unfortunately, Squirrel does not support "ON CONFLUCT" statement correctly (refer https://github.com/Masterminds/squirrel/issues/83#issuecomment-348242549) so I have to use `.Suffix` method to manually construct the statement.

After changing this implementation, my test application was running fine creating 1,000 actors