### PR TITLE
fix: stop publisher/saga event-stream loops busy-spinning 100% CPU 

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -1134,13 +1134,26 @@ func toSupervisorDirective(directive SupervisorDirective) supervisor.Directive {
 	}
 }
 
-// sendEvent sends events to the event publisher
+// sendEvent sends events to the event publisher.
+// It blocks on the subscriber's Ready signal when idle, then drains the
+// snapshot returned by Iterator. Selecting on Iterator directly would
+// busy-spin a CPU core: it returns a closed snapshot channel that yields
+// nil immediately whenever the queue is empty.
 func (engine *Engine) sendEvent(stream *eventsStream) {
 	for {
 		select {
 		case <-stream.done:
 			return
-		case message := <-stream.subscriber.Iterator():
+		case <-stream.subscriber.Ready():
+		}
+
+		for message := range stream.subscriber.Iterator() {
+			select {
+			case <-stream.done:
+				return
+			default:
+			}
+
 			if message == nil {
 				continue
 			}
@@ -1167,13 +1180,26 @@ func (engine *Engine) sendEvent(stream *eventsStream) {
 	}
 }
 
-// sendState sends state changes to the state publisher
+// sendState sends state changes to the state publisher.
+// It blocks on the subscriber's Ready signal when idle, then drains the
+// snapshot returned by Iterator. Selecting on Iterator directly would
+// busy-spin a CPU core: it returns a closed snapshot channel that yields
+// nil immediately whenever the queue is empty.
 func (engine *Engine) sendState(stream *statesStream) {
 	for {
 		select {
 		case <-stream.done:
 			return
-		case message := <-stream.subscriber.Iterator():
+		case <-stream.subscriber.Ready():
+		}
+
+		for message := range stream.subscriber.Iterator() {
+			select {
+			case <-stream.done:
+				return
+			default:
+			}
+
 			if message == nil {
 				continue
 			}

--- a/engine_test.go
+++ b/engine_test.go
@@ -27,6 +27,7 @@ import (
 	"errors"
 	"net"
 	"strconv"
+	"syscall"
 	"testing"
 	"time"
 
@@ -919,6 +920,57 @@ func TestEngineAddEventPublishers(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for event publish")
 	}
+}
+
+// TestEnginePublisherIdleCPU is the regression test for
+// https://github.com/Tochemey/ego/issues/291: the publisher consumption
+// loops used to poll Subscriber.Iterator() — which returns a closed snapshot
+// channel — in a tight select, pinning one full CPU core per registered
+// publisher whenever the stream was idle. Post-fix the loops block on the
+// subscriber's Ready signal, so an idle engine with publishers must consume
+// close to zero CPU.
+func TestEnginePublisherIdleCPU(t *testing.T) {
+	ctx := context.Background()
+	store := testkit.NewEventsStore()
+	require.NoError(t, store.Connect(ctx))
+	t.Cleanup(func() { _ = store.Disconnect(ctx) })
+
+	eventPub := new(egomock.EventPublisher)
+	eventPub.On("ID").Return("eGo.test.EventPublisher")
+	eventPub.On("Close", mock.Anything).Return(nil)
+
+	statePub := new(egomock.StatePublisher)
+	statePub.On("ID").Return("eGo.test.StatePublisher")
+	statePub.On("Close", mock.Anything).Return(nil)
+
+	engine := newTestEngine(t, "Sample", store, WithLogger(DiscardLogger))
+	require.NoError(t, engine.Start(ctx))
+	require.NoError(t, engine.AddEventPublishers(eventPub))
+	require.NoError(t, engine.AddStatePublishers(statePub))
+
+	// let startup work settle before sampling
+	pause.For(500 * time.Millisecond)
+
+	cpuStart := processCPUTime(t)
+	const idle = 2 * time.Second
+	pause.For(idle)
+	cpuBurned := processCPUTime(t) - cpuStart
+
+	// Pre-fix, each of the two idle consumption loops burned a full core
+	// (~2s of CPU each over the 2s window). The threshold leaves generous
+	// headroom for runtime and actor-system background work while still
+	// catching any loop that spins instead of blocking.
+	require.Less(t, cpuBurned, idle/2,
+		"idle publisher loops burned %v of CPU over %v of wall time: busy-spin regression", cpuBurned, idle)
+}
+
+// processCPUTime returns the cumulative user+system CPU time of the test
+// process.
+func processCPUTime(t *testing.T) time.Duration {
+	t.Helper()
+	var usage syscall.Rusage
+	require.NoError(t, syscall.Getrusage(syscall.RUSAGE_SELF, &usage))
+	return time.Duration(usage.Utime.Nano() + usage.Stime.Nano())
 }
 
 // TestEngineAddStatePublishers exercises the happy path of

--- a/eventstream/stream_test.go
+++ b/eventstream/stream_test.go
@@ -88,6 +88,55 @@ func TestStream(t *testing.T) {
 		}
 	})
 
+	t.Run("With Ready signaling", func(t *testing.T) {
+		sub := newSubscriber()
+
+		// no message yet: Ready must not fire
+		select {
+		case <-sub.Ready():
+			require.Fail(t, "Ready fired without any message")
+		default:
+		}
+
+		// a signal wakes a consumer blocked on Ready
+		sub.signal(NewMessage("a", "one"))
+		select {
+		case <-sub.Ready():
+		case <-time.After(time.Second):
+			require.Fail(t, "Ready did not fire after signal")
+		}
+
+		// coalescing: many signals while no one is draining keep at most one
+		// pending wake-up, and a single drain still sees every message
+		sub.signal(NewMessage("a", "two"))
+		sub.signal(NewMessage("a", "three"))
+		<-sub.Ready()
+		var seen []*Message
+		for msg := range sub.Iterator() {
+			seen = append(seen, msg)
+		}
+		require.Len(t, seen, 3)
+		select {
+		case <-sub.Ready():
+			require.Fail(t, "Ready should have at most one pending wake-up")
+		default:
+		}
+
+		// Shutdown wakes a consumer blocked on Ready
+		done := make(chan struct{})
+		go func() {
+			<-sub.Ready()
+			close(done)
+		}()
+		sub.Shutdown()
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			require.Fail(t, "Ready did not fire on shutdown")
+		}
+		require.False(t, sub.Active())
+	})
+
 	t.Run("With Subscription", func(t *testing.T) {
 		broker := New()
 

--- a/eventstream/subscriber.go
+++ b/eventstream/subscriber.go
@@ -37,6 +37,12 @@ type Subscriber interface {
 	Active() bool
 	Topics() []string
 	Iterator() chan *Message
+	// Ready returns a channel that receives a signal whenever new messages
+	// are available to drain via Iterator, or when the subscriber shuts down.
+	// Block on Ready instead of calling Iterator in a tight loop: Iterator
+	// returns a closed snapshot channel, so polling it while the queue is
+	// empty busy-spins a CPU core.
+	Ready() <-chan struct{}
 	Shutdown()
 	signal(message *Message)
 	subscribe(topic string)
@@ -55,6 +61,10 @@ type subscriber struct {
 	topics map[string]bool
 	// states whether the given subscriber is active or not
 	active *atomic.Bool
+	// notify wakes consumers blocked on Ready when a message is enqueued
+	// or the subscriber shuts down. Capacity one: a pending wake-up already
+	// guarantees the next Iterator drain sees every enqueued message.
+	notify chan struct{}
 }
 
 var _ Subscriber = &subscriber{}
@@ -72,6 +82,7 @@ func newSubscriber() *subscriber {
 		messages: queue.NewQueue(),
 		topics:   make(map[string]bool),
 		active:   atomic.NewBool(true),
+		notify:   make(chan struct{}, 1),
 	}
 }
 
@@ -101,6 +112,17 @@ func (x *subscriber) Topics() []string {
 // Shutdown shutdowns the consumer
 func (x *subscriber) Shutdown() {
 	x.active.Store(false)
+	// wake any consumer blocked on Ready so it can observe the shutdown
+	select {
+	case x.notify <- struct{}{}:
+	default:
+	}
+}
+
+// Ready returns a channel that receives a signal whenever new messages are
+// available to drain via Iterator, or when the subscriber shuts down.
+func (x *subscriber) Ready() <-chan struct{} {
+	return x.notify
 }
 
 func (x *subscriber) Iterator() chan *Message {
@@ -130,6 +152,13 @@ func (x *subscriber) signal(message *Message) {
 	// only receive message when active
 	if x.active.Load() {
 		x.messages.Enqueue(message)
+		// wake a consumer blocked on Ready. Dropping the send when the
+		// buffer is full is safe: the pending wake-up's drain will pick
+		// this message up too.
+		select {
+		case x.notify <- struct{}{}:
+		default:
+		}
 	}
 }
 

--- a/saga_actor.go
+++ b/saga_actor.go
@@ -54,11 +54,12 @@ type SagaActor struct {
 	sagaID        string
 	timeout       time.Duration
 
-	// actorSystem and logger are stored during PostStart so that the
+	// actorSystem, logger and self are stored during PostStart so that the
 	// consumeEvents goroutine can use them safely after the ReceiveContext
 	// from PostStart has been returned to the pool.
 	actorSystem goakt.ActorSystem
 	logger      log.Logger
+	self        *goakt.PID
 
 	// stopCh is used to stop the event consumption loop
 	stopCh chan struct{}
@@ -118,12 +119,18 @@ func (s *SagaActor) PreStart(ctx *goakt.Context) error {
 }
 
 // Receive handles messages sent to the saga actor.
+//
+// All saga state (currentState, eventsCounter, status) is read and written
+// exclusively from here: the consumeEvents goroutine forwards stream events
+// to the actor's own mailbox instead of processing them itself, so the
+// actor's serialized message loop is the only writer.
 func (s *SagaActor) Receive(ctx *goakt.ReceiveContext) {
-	switch ctx.Message().(type) {
+	switch message := ctx.Message().(type) {
 	case *goakt.PostStart:
 		// Capture stable references before the ReceiveContext is returned to the pool.
 		s.actorSystem = ctx.ActorSystem()
 		s.logger = ctx.Logger()
+		s.self = ctx.Self()
 		// Start consuming events from the stream
 		go s.consumeEvents()
 		// Schedule timeout if configured
@@ -131,6 +138,8 @@ func (s *SagaActor) Receive(ctx *goakt.ReceiveContext) {
 			self := ctx.Self()
 			_ = ctx.ActorSystem().ScheduleOnce(ctx.Context(), &sagaTimeoutMsg{}, self, s.timeout)
 		}
+	case *egopb.Event:
+		s.handleStreamEvent(message)
 	case *sagaTimeoutMsg:
 		if s.status == SagaRunning {
 			s.status = SagaCompensating
@@ -188,20 +197,35 @@ func (s *SagaActor) recover(ctx context.Context) error {
 	return nil
 }
 
-// consumeEvents reads events from the stream and processes them via the behavior.
-// It uses the stable actorSystem and logger fields captured during PostStart instead
-// of the ReceiveContext (which is returned to the pool once Receive returns).
+// consumeEvents pumps events from the stream into the actor's own mailbox.
+// It uses the stable actorSystem, logger and self fields captured during
+// PostStart instead of the ReceiveContext (which is returned to the pool once
+// Receive returns).
+//
+// It blocks on the subscriber's Ready signal when idle, then drains the
+// snapshot returned by Iterator. Selecting on Iterator directly would
+// busy-spin a CPU core: it returns a closed snapshot channel that yields
+// nil immediately whenever the queue is empty.
+//
+// Events are forwarded to the mailbox rather than processed here so that all
+// saga state stays owned by the actor's serialized message loop — processing
+// them on this goroutine would race with Receive (state queries, timeout).
 func (s *SagaActor) consumeEvents() {
 	for {
 		select {
 		case <-s.stopCh:
 			return
-		case message := <-s.subscriber.Iterator():
-			if message == nil {
-				continue
+		case <-s.subscriber.Ready():
+		}
+
+		for message := range s.subscriber.Iterator() {
+			select {
+			case <-s.stopCh:
+				return
+			default:
 			}
 
-			if s.status != SagaRunning {
+			if message == nil {
 				continue
 			}
 
@@ -215,21 +239,33 @@ func (s *SagaActor) consumeEvents() {
 				continue
 			}
 
-			eventMsg, err := event.GetEvent().UnmarshalNew()
-			if err != nil {
-				s.logger.Errorf("saga %s: failed to unmarshal event: %v", s.sagaID, err)
-				continue
+			if err := s.actorSystem.NoSender().Tell(context.Background(), s.self, event); err != nil {
+				s.logger.Errorf("saga %s: failed to forward event to mailbox: %v", s.sagaID, err)
 			}
-
-			action, err := s.behavior.HandleEvent(context.Background(), eventMsg.(Event), s.currentState)
-			if err != nil {
-				s.logger.Errorf("saga %s: HandleEvent failed: %v", s.sagaID, err)
-				continue
-			}
-
-			s.processAction(action)
 		}
 	}
+}
+
+// handleStreamEvent processes a stream event forwarded by consumeEvents.
+// It runs on the actor's message loop, so it can freely touch saga state.
+func (s *SagaActor) handleStreamEvent(event *egopb.Event) {
+	if s.status != SagaRunning {
+		return
+	}
+
+	eventMsg, err := event.GetEvent().UnmarshalNew()
+	if err != nil {
+		s.logger.Errorf("saga %s: failed to unmarshal event: %v", s.sagaID, err)
+		return
+	}
+
+	action, err := s.behavior.HandleEvent(context.Background(), eventMsg.(Event), s.currentState)
+	if err != nil {
+		s.logger.Errorf("saga %s: HandleEvent failed: %v", s.sagaID, err)
+		return
+	}
+
+	s.processAction(action)
 }
 
 // processAction executes a SagaAction: persists saga events, sends commands, and handles completion/compensation.

--- a/saga_test.go
+++ b/saga_test.go
@@ -24,6 +24,7 @@ package ego
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -704,11 +705,13 @@ func TestSagaActor(t *testing.T) {
 		require.NoError(t, actorSystem.Start(ctx))
 		pause.For(time.Second)
 
-		callCount := 0
+		// the saga processes events on its own goroutine, so the counter must
+		// be atomic for the test goroutine to read it safely
+		var callCount atomic.Int32
 		behavior := &callbackSagaBehavior{
 			id: sagaID,
 			handleEvent: func(_ context.Context, _ Event, _ State) (*SagaAction, error) {
-				callCount++
+				callCount.Add(1)
 				return &SagaAction{Complete: true}, nil
 			},
 		}
@@ -733,14 +736,14 @@ func TestSagaActor(t *testing.T) {
 		stream.Publish(topic, domainEvent)
 		pause.For(500 * time.Millisecond)
 
-		countAfterFirst := callCount
+		countAfterFirst := callCount.Load()
 
 		// Subsequent events should be ignored
 		stream.Publish(topic, domainEvent)
 		stream.Publish(topic, domainEvent)
 		pause.For(500 * time.Millisecond)
 
-		assert.Equal(t, countAfterFirst, callCount, "HandleEvent should not be called after saga completes")
+		assert.Equal(t, countAfterFirst, callCount.Load(), "HandleEvent should not be called after saga completes")
 
 		stream.Close()
 		require.NoError(t, actorSystem.Stop(ctx))
@@ -1013,7 +1016,9 @@ func TestSagaActor(t *testing.T) {
 		pause.For(time.Second)
 
 		handled := make(chan struct{}, 1)
-		applyCallCount := 0
+		// the saga processes events on its own goroutine, so the counter must
+		// be atomic for the test goroutine to read it safely
+		var applyCallCount atomic.Int32
 		behavior := &callbackSagaBehavior{
 			id: sagaID,
 			handleEvent: func(_ context.Context, event Event, _ State) (*SagaAction, error) {
@@ -1021,7 +1026,7 @@ func TestSagaActor(t *testing.T) {
 				return &SagaAction{Events: []Event{event}}, nil
 			},
 			applyEvent: func(_ context.Context, _ Event, state State) (State, error) {
-				applyCallCount++
+				applyCallCount.Add(1)
 				return nil, assert.AnError
 			},
 		}
@@ -1048,7 +1053,7 @@ func TestSagaActor(t *testing.T) {
 
 		// Actor must still be alive despite the error
 		require.True(t, pid.IsRunning())
-		assert.Positive(t, applyCallCount)
+		assert.Positive(t, applyCallCount.Load())
 
 		stream.Close()
 		require.NoError(t, actorSystem.Stop(ctx))


### PR DESCRIPTION
closes #291 

Subscriber.Iterator() returns a closed snapshot channel, so the consumption
loops in Engine.sendEvent, Engine.sendState and SagaActor.consumeEvents
received nil instantly and re-polled forever, pinning one CPU core per
registered publisher/saga even when completely idle.

- eventstream: add Subscriber.Ready(), a capacity-1 notification channel
  signaled on enqueue and shutdown. Iterator() keeps its public snapshot
  semantics; consumers now block on Ready() when idle and drain the
  snapshot when woken.
- engine: sendEvent/sendState block on Ready() instead of polling
  Iterator(), re-checking done between messages for prompt shutdown.
- saga: consumeEvents is now a pure pump that forwards stream events to
  the actor's own mailbox. This also fixes a pre-existing data race the
  blocking loops exposed: currentState/eventsCounter/status were mutated
  by the consumer goroutine while Receive (state queries, timeout) read
  them. All saga state is now owned by the serialized message loop.
- tests: add TestEnginePublisherIdleCPU regression test (pre-fix it
  measures ~5.2s CPU over a 2s idle window; post-fix near zero), cover
  Ready() signaling/coalescing, and make saga test counters atomic.